### PR TITLE
fix #177 - 관리자 페이지 버튼 클릭시 main 으로 이동하는 라우트 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,7 +69,7 @@ export default function App() {
               element={<InterviewViewPage />}
             />
             <Route
-              path="/admin"
+              path="/admin/*"
               element={
                 <CheckAdminUuid>
                   <AdminPage />

--- a/src/components/adminpage/AdminMain.tsx
+++ b/src/components/adminpage/AdminMain.tsx
@@ -1,10 +1,11 @@
 interface AdminPageProps {
-  onUserClick: () => void;
-  onQuestionClick: () => void;
+  onUserClick?: () => void;
+  onQuestionClick?: () => void;
 }
 
 import { faQuestion, faUsers } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Link } from 'react-router-dom';
 
 export default function AdminMainPage({
   onUserClick,
@@ -12,7 +13,8 @@ export default function AdminMainPage({
 }: AdminPageProps) {
   return (
     <div className="h-full bg-gray-50 flex justify-center items-center gap-8">
-      <div
+      <Link
+        to="user"
         className="w-96 h-96 bg-white border-2 border-gray-200 flex flex-col justify-center items-center rounded-2xl shadow-lg hover:shadow-xl transition-shadow cursor-pointer"
         onClick={onUserClick}
       >
@@ -20,9 +22,10 @@ export default function AdminMainPage({
         <h2 className="text-xl font-semibold text-gray-700 mt-3">
           유저 정보 리스트
         </h2>
-      </div>
+      </Link>
 
-      <div
+      <Link
+        to="question"
         className="w-96 h-96 bg-white border-2 border-gray-200 flex flex-col justify-center items-center rounded-2xl shadow-lg hover:shadow-xl transition-shadow cursor-pointer"
         onClick={onQuestionClick}
       >
@@ -30,7 +33,7 @@ export default function AdminMainPage({
         <h2 className="text-xl font-semibold text-gray-700 mt-3">
           질문 리스트
         </h2>
-      </div>
+      </Link>
     </div>
   );
 }

--- a/src/components/adminpage/QuestionList.tsx
+++ b/src/components/adminpage/QuestionList.tsx
@@ -1,7 +1,3 @@
-type setViewType = {
-  setView: (view: 'main' | 'user' | 'question') => void;
-};
-
 interface Question {
   question_id: number;
   category: string;
@@ -21,8 +17,9 @@ import { faCaretLeft } from '@fortawesome/free-solid-svg-icons';
 import { H4_placeholder } from '../common/HTagStyle';
 import { useToast } from '../../hooks/useToast';
 import { useModal } from '../../hooks/useModal';
+import { useNavigate } from 'react-router-dom';
 
-export default function QuestionList({ setView }: setViewType) {
+export default function QuestionList() {
   const [questions, setQuestions] = useState<Question[]>([]);
   const [selectedCategory, setSelectedCategory] = useState<string>('');
   const [selectedTopic, setSelectedTopic] = useState<string>('');
@@ -30,6 +27,7 @@ export default function QuestionList({ setView }: setViewType) {
   const [adding, setAdding] = useState(false);
   const [editId, setEditId] = useState<number | null>(null);
   const [editContent, setEditContent] = useState('');
+  const navigate = useNavigate();
 
   const toast = useToast();
   const modal = useModal();
@@ -146,7 +144,7 @@ export default function QuestionList({ setView }: setViewType) {
     <div className="flex flex-col mx-auto mt-6 p-6 bg-white rounded-xl shadow-sm border border-slate-200">
       <div
         className="flex items-center gap-2 cursor-pointer mb-6 text-slate-500 hover:text-slate-700 transition-colors duration-200 w-fit"
-        onClick={() => setView('main')}
+        onClick={() => navigate('/admin')}
       >
         <FontAwesomeIcon icon={faCaretLeft} size={'lg'} />
         <H4_placeholder>뒤로가기</H4_placeholder>

--- a/src/components/adminpage/UserList.tsx
+++ b/src/components/adminpage/UserList.tsx
@@ -5,10 +5,6 @@ interface User {
   created_at: string;
 }
 
-type setViewType = {
-  setView: (view: 'main' | 'user' | 'question') => void;
-};
-
 import { useState, useEffect } from 'react';
 import { fetchUsers, updateUser, deleteUser } from '../../api/adminPageApi';
 import { H4_placeholder } from '../common/HTagStyle';
@@ -17,8 +13,9 @@ import { faCaretLeft, faUser } from '@fortawesome/free-solid-svg-icons';
 import Button from '../common/Button';
 import { useModal } from '../../hooks/useModal';
 import { useToast } from '../../hooks/useToast';
+import { Navigate, useNavigate } from 'react-router-dom';
 
-export default function UserList({ setView }: setViewType) {
+export default function UserList() {
   const [users, setUsers] = useState<User[]>([]);
   const [selectedUser, setSelectedUser] = useState<User | null>(null);
   const [activeTab, setActiveTab] = useState('info');
@@ -27,6 +24,8 @@ export default function UserList({ setView }: setViewType) {
   const [isEditing, setIsEditing] = useState(false);
   const [editedNickname, setEditedNickname] = useState('');
   const [isNameError, setIsNameError] = useState(false);
+
+  const navigate = useNavigate();
 
   // 모달 추가
   const modal = useModal();
@@ -147,7 +146,7 @@ export default function UserList({ setView }: setViewType) {
         <div className="p-6 border-b border-slate-100 flex items-center justify-between">
           <div
             className="flex items-center gap-2 cursor-pointer text-slate-500 hover:text-[#427CF5] transition-colors duration-200 w-fit"
-            onClick={() => setView('main')}
+            onClick={() => navigate('/admin')}
           >
             <FontAwesomeIcon icon={faCaretLeft} size={'lg'} />
             <H4_placeholder>뒤로가기</H4_placeholder>

--- a/src/page/AdminPage.tsx
+++ b/src/page/AdminPage.tsx
@@ -1,20 +1,25 @@
-import { useState } from 'react';
+import { Routes, Route } from 'react-router-dom';
 import AdminMainPage from '../components/adminpage/AdminMain';
 import UserList from '../components/adminpage/UserList';
 import QuestionList from '../components/adminpage/QuestionList';
 
 export default function AdminPage() {
-  const [view, setView] = useState<'main' | 'user' | 'question'>('main');
   return (
-    <>
-      {view === 'main' && (
-        <AdminMainPage
-          onUserClick={() => setView('user')}
-          onQuestionClick={() => setView('question')}
-        />
-      )}
-      {view === 'user' && <UserList setView={setView} />}
-      {view === 'question' && <QuestionList setView={setView} />}
-    </>
+    <Routes>
+      <Route index element={<AdminMainPage />} />
+      <Route path="user" element={<UserList />} />
+      <Route path="question" element={<QuestionList />} />
+    </Routes>
+
+    // <>
+    //   {view === 'main' && (
+    //     <AdminMainPage
+    //       onUserClick={() => setView('user')}
+    //       onQuestionClick={() => setView('question')}
+    //     />
+    //   )}
+    //   {view === 'user' && <UserList setView={setView} />}
+    //   {view === 'question' && <QuestionList setView={setView} />}
+    // </>
   );
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#177 

## ✏️ 개요

- App.tsx 에서  /admin/user, /admin/question 같은 하위 경로까지 `*` 추가
- AdminPage.tsx 에 중첩 라우팅 구조 도입. 
- props 를 to = "user" to = "question" 으로 감쌈
- type 삭제 , setViews삭제 하고 라우터로 이동


## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention 참고](https://www.notion.so/goormkdx/214c0ff4ce31802c8b91fcad2e545fc4?source=copy_link#238c0ff4ce31806594e2fcfe9b212619)  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
