### PR TITLE
fix#187 admin question filter

### DIFF
--- a/src/api/adminPageApi.ts
+++ b/src/api/adminPageApi.ts
@@ -68,7 +68,7 @@ export async function deleteQuestion(question_id: number) {
 // 카테고리 정보 가져오기
 export async function fetchCategories() {
   const { data, error } = await supabase
-    .from('quesionts')
+    .from('questions')
     .select('category', { count: 'exact' })
     .neq('category', null)
     .order('category', { ascending: true });

--- a/src/api/adminPageApi.ts
+++ b/src/api/adminPageApi.ts
@@ -85,3 +85,15 @@ export async function fetchCategories() {
   const uniqueCategories = [...new Set(data.map((q) => q.category))];
   return uniqueCategories;
 }
+
+// 토픽 정보 가져오기
+export async function fetchTopics(category: string) {
+  const { data, error } = await supabase
+    .from('questions')
+    .select('topic')
+    .eq('category', category)
+    .neq('topic', null);
+
+  if (error) throw error;
+  return [...new Set(data.map((row) => row.topic))];
+}

--- a/src/api/adminPageApi.ts
+++ b/src/api/adminPageApi.ts
@@ -64,3 +64,17 @@ export async function deleteQuestion(question_id: number) {
     .delete()
     .eq('question_id', question_id);
 }
+
+// 카테고리 정보 가져오기
+export async function fetchCategories() {
+  const { data, error } = await supabase
+    .from('quesionts')
+    .select('category', { count: 'exact' })
+    .neq('category', null)
+    .order('category', { ascending: true });
+
+  if (error) throw error;
+
+  const uniqueCategories = [...new Set(data.map((q) => q.category))];
+  return uniqueCategories;
+}

--- a/src/api/adminPageApi.ts
+++ b/src/api/adminPageApi.ts
@@ -18,22 +18,29 @@ export async function deleteUser(user_id: string) {
 }
 
 // 질문 전체 조회
-export async function fetchQuestions(page: number = 1, perPage: number = 10) {
+export async function fetchQuestions(
+  page: number = 1,
+  perPage: number,
+  filter?: { category?: string; topic?: string },
+) {
   const from = (page - 1) * perPage;
   const to = from + perPage - 1;
-  const { data, count, error } = await supabase
+
+  let query = supabase
     .from('questions')
     .select('*', { count: 'exact' })
     .range(from, to)
     .order('question_id', { ascending: true });
 
+  if (filter?.category) query = query.eq('category', filter.category);
+  if (filter?.topic) query = query.eq('topic', filter.topic);
+
+  const { data, count, error } = await query;
   if (error) throw error;
 
   return {
     questions: data ?? [],
     total: count ?? 0,
-    page,
-    perPage,
   };
 }
 

--- a/src/components/adminpage/QuestionList.tsx
+++ b/src/components/adminpage/QuestionList.tsx
@@ -11,6 +11,7 @@ import {
   addQuestion,
   updateQuestion,
   deleteQuestion,
+  fetchCategories,
 } from '../../api/adminPageApi';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCaretLeft } from '@fortawesome/free-solid-svg-icons';
@@ -23,6 +24,7 @@ export default function QuestionList() {
   const [questions, setQuestions] = useState<Question[]>([]);
   const [selectedCategory, setSelectedCategory] = useState<string>('');
   const [selectedTopic, setSelectedTopic] = useState<string>('');
+  const [categoryList, setCategoryList] = useState<string[]>([]);
   const [newContent, setNewContent] = useState('');
   const [adding, setAdding] = useState(false);
   const [editId, setEditId] = useState<number | null>(null);
@@ -39,21 +41,35 @@ export default function QuestionList() {
   const PAGE_SIZE = 10;
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
-  const loadPage = async (p: number) => {
-    const { questions, total } = await fetchQuestions(p, PAGE_SIZE);
-    setQuestions(questions);
-    setTotal(total);
-    setPage(p);
-  };
-
   const categoryTopicMap: Record<string, string[]> = {
     'front-end': ['react', 'javascript', 'nextjs'],
     cs: ['network', 'rendering'],
     git: ['git'],
   };
 
+  //질문 불러오기
+  const loadPage = async (p: number) => {
+    const { questions, total } = await fetchQuestions(p, PAGE_SIZE);
+    setQuestions(questions);
+    setTotal(total);
+    setPage(p);
+  };
+  // 질문 불러오기
   useEffect(() => {
     loadPage(1);
+  }, []);
+
+  // 카테고리 불러오기
+  useEffect(() => {
+    (async () => {
+      try {
+        const categories = await fetchCategories();
+        setCategoryList(categories);
+        setSelectedCategory(categories[0] ?? '');
+      } catch (err: any) {
+        toast('카테고리 로드에 실패했습니다.\n' + err.message, 'error');
+      }
+    })();
   }, []);
 
   const handleCategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -208,12 +224,27 @@ export default function QuestionList() {
 
       {/* 카테고리 필터 */}
       <div className="mb-3">
-        <ul className="flex gap-5">
-          <li
-            className={`px-4 py-1.5 rounded-full border-2 text-sm cursor-pointer transition-colors`}
-          >
-            front-end
-          </li>
+        <ul className="flex gap-2">
+          {categoryList.map((category) => {
+            const isSelected = selectedCategory === category;
+            return (
+              <li
+                key={category}
+                onClick={() => {
+                  setSelectedCategory(category);
+                  setSelectedTopic('');
+                  loadPage(1);
+                }}
+                className={`px-3 py-1 rounded-2xl border-2 text-sm cursor-pointer transition-colors ${
+                  isSelected
+                    ? 'bg-blue-50 text-blue-700 border-blue-300'
+                    : 'bg-white text-gray-100 border-gray-300 hover:bg-gray-50'
+                }`}
+              >
+                {category}
+              </li>
+            );
+          })}
         </ul>
       </div>
 

--- a/src/components/adminpage/QuestionList.tsx
+++ b/src/components/adminpage/QuestionList.tsx
@@ -158,7 +158,7 @@ export default function QuestionList() {
         <H4_placeholder>뒤로가기</H4_placeholder>
       </div>
 
-      <div className="mb-6 flex gap-4">
+      <div className="mb-3 flex gap-4">
         <select
           className="border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#427CF5] focus:border-[#427CF5] transition-all duration-200"
           required
@@ -205,6 +205,18 @@ export default function QuestionList() {
           추가
         </button>
       </div>
+
+      {/* 카테고리 필터 */}
+      <div className="mb-3">
+        <ul className="flex gap-5">
+          <li
+            className={`px-4 py-1.5 rounded-full border-2 text-sm cursor-pointer transition-colors`}
+          >
+            front-end
+          </li>
+        </ul>
+      </div>
+
       <div>
         <ul className="flex rounded-lg font-medium text-slate-700 text-sm mb-2 bg-slate-50 py-3">
           <li className="flex-[0.8] text-center">#</li>

--- a/src/components/adminpage/QuestionList.tsx
+++ b/src/components/adminpage/QuestionList.tsx
@@ -25,6 +25,7 @@ export default function QuestionList() {
   const [selectedCategory, setSelectedCategory] = useState<string>('');
   const [selectedTopic, setSelectedTopic] = useState<string>('');
   const [categoryList, setCategoryList] = useState<string[]>([]);
+  const [topicList, setTopicList] = useState<string[]>([]);
   const [newContent, setNewContent] = useState('');
   const [adding, setAdding] = useState(false);
   const [editId, setEditId] = useState<number | null>(null);
@@ -187,11 +188,13 @@ export default function QuestionList() {
           <option value="" disabled>
             카테고리
           </option>
-          {Object.keys(categoryTopicMap).map((cat) => (
-            <option key={cat} value={cat}>
-              {cat}
-            </option>
-          ))}
+          {categoryList.map((category) => {
+            return (
+              <option key={category} value={category}>
+                {category}
+              </option>
+            );
+          })}
         </select>
         <select
           className="border border-slate-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#427CF5] focus:border-[#427CF5] transition-all duration-200"

--- a/src/components/adminpage/QuestionList.tsx
+++ b/src/components/adminpage/QuestionList.tsx
@@ -48,16 +48,19 @@ export default function QuestionList() {
   };
 
   //질문 불러오기
-  const loadPage = async (p: number) => {
-    const { questions, total } = await fetchQuestions(p, PAGE_SIZE);
+  const loadPage = async (page: number) => {
+    const { questions, total } = await fetchQuestions(page, PAGE_SIZE, {
+      category: selectedCategory,
+      topic: selectedTopic,
+    });
     setQuestions(questions);
     setTotal(total);
-    setPage(p);
+    setPage(page);
   };
   // 질문 불러오기
   useEffect(() => {
     loadPage(1);
-  }, []);
+  }, [selectedCategory, selectedTopic]);
 
   // 카테고리 불러오기
   useEffect(() => {


### PR DESCRIPTION
## #️⃣ Issue Number

#187 

## ✏️ 개요

- 관리자 페이지 질문 목록 필터링 기능 개선
- 카테고리, 토픽 데이터 DB 기반으로 동적 로딩하도록 수정
- 카테고리 선택 시 debounce 적용하여 연타 방지
- 기존 하드코딩된 `categoryTopicMap` 제거 및 관련 로직 리팩


## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)

## 💬 공유사항
현재 그냥 DB에서 받아오는 구조(정렬 o) 로 인해서 ui 부분이 cs 먼저 출력됩니다.
이 부분 거슬리면 말씀해 주세요

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention 참고](https://www.notion.so/goormkdx/214c0ff4ce31802c8b91fcad2e545fc4?source=copy_link#238c0ff4ce31806594e2fcfe9b212619)  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
