### PR TITLE
Refactor/185 user delete confirmation fix

### DIFF
--- a/src/api/adminPageApi.ts
+++ b/src/api/adminPageApi.ts
@@ -14,7 +14,10 @@ export async function updateUser(user_id: string, data: any) {
 
 // 유저 삭제
 export async function deleteUser(user_id: string) {
-  return await supabase.from('user').delete().eq('user_id', user_id);
+  return await supabase
+    .from('user')
+    .update({ is_deleted: true })
+    .eq('user_id', user_id);
 }
 
 // 질문 전체 조회

--- a/src/page/LoginPage.tsx
+++ b/src/page/LoginPage.tsx
@@ -11,8 +11,11 @@ import { supabase } from '../supabaseClient';
 
 import { loginUserInfo } from '../api/userInfo';
 import { useLoggedInStore, useUserDataStore } from '../store/userData';
+import { useToast } from '../hooks/useToast';
 
 export default function LoginPage() {
+  const toast = useToast();
+
   const [email, setEmail] = useState('');
   const [userPassword, setUserPassword] = useState('');
 
@@ -44,6 +47,12 @@ export default function LoginPage() {
 
       if (userInfoError || !userInfo || userInfo.length === 0) {
         throw new Error('유저 정보를 불러오지 못했습니다.');
+      }
+
+      if (userInfo[0].is_deleted === true) {
+        await supabase.auth.signOut();
+        alert('탈퇴된 계정입니다. 관리자에게 문의하세요.');
+        return;
       }
 
       setUserData({


### PR DESCRIPTION
## #️⃣ Issue Number
#185 

## ✏️ 개요
- 관리자 페이지에서 유저 삭제 시 UI에서는 반영되지만, 실제 DB에서는 삭제되지 않는 문제 발생
- Supabase 정책상 사용자는 자신의 정보만 수정/삭제할 수 있으므로, 타인 계정에 대한 수정/삭제 시 toast 메시지 표시
- 삭제 처리된 사용자는 로그인할 수 없도록 로그인 로직 수정

## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention 참고](https://www.notion.so/goormkdx/214c0ff4ce31802c8b91fcad2e545fc4?source=copy_link#238c0ff4ce31806594e2fcfe9b212619)  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
