### PR TITLE
fix #208 - 피드백 재제출 방지

### DIFF
--- a/src/components/interviewpage/AnswerInput.tsx
+++ b/src/components/interviewpage/AnswerInput.tsx
@@ -65,6 +65,8 @@ export default function AnswerInput({
 
   const voiceRecordingRef = useRef<VoiceRecording | null>(null);
 
+  const lastAnswerRef = useRef(initialAnswer);
+
   const setRadarData = useRadarChartData((state) => state.setRadarData);
 
   // AbortController 적용
@@ -175,26 +177,27 @@ export default function AnswerInput({
 
   // 답변 수정
   const handleAnswerChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setAnswer(e.target.value);
-    setIsDirty(true);
+    const value = e.target.value;
+    setAnswer(value);
+    setIsDirty(value.trim() !== lastAnswerRef.current.trim());
   };
 
   const handleFeedback = useCallback(async () => {
+    if (!answer.trim()) {
+      toast('먼저 질문에 대한 답변을 해주세요.', 'info');
+      return;
+    }
     // 동일 답변 방지
     if (answer == initialAnswer) {
       toast('기존 답변과 동일해요. 내용을 수정해 주세요.', 'info');
       return;
     }
 
-    if (hasFeedback && !isDirty) {
+    if (answer.trim() === lastAnswerRef.current.trim()) {
       toast('이미 제출한 답변이에요. 내용을 수정해 주세요.', 'info');
       return;
     }
 
-    if (!answer.trim()) {
-      toast('먼저 질문에 대한 답변을 해주세요.', 'info');
-      return;
-    }
     controllerRef.current?.abort();
     controllerRef.current = new AbortController();
     setLoading(true);
@@ -245,6 +248,7 @@ export default function AnswerInput({
 
       setRadarData(scores);
       setEditAnswer(answer);
+      lastAnswerRef.current = answer.trim();
       setHasFeedback(true);
       setIsDirty(false);
       toast('피드백을 가져왔어요!', 'success');


### PR DESCRIPTION
## #️⃣ Issue Number

#208 

## ✏️ 개요

useRef 활용하여, 마지막 제출 답변 메모리 보관,
answer.trim() === lastAnswerRef.current.trim() 조건을 통해 동일 답변 다시 제출되지 않도록 제한


## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)

## 💬 공유사항
<!--- 논의해야할 부분이 있다면 적어주세요.-->

## ✅ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention 참고](https://www.notion.so/goormkdx/214c0ff4ce31802c8b91fcad2e545fc4?source=copy_link#238c0ff4ce31806594e2fcfe9b212619)  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
